### PR TITLE
refactor aero: internal/external frame pattern (bad pr)

### DIFF
--- a/src/vehicle/aero/aero.h
+++ b/src/vehicle/aero/aero.h
@@ -1,18 +1,27 @@
 #pragma once
 
 #include "config/config.h"
+#include "coordTypes.h"
+#include "types.h"
 #include "vehicle/vehicleHelper.h"
 
-template <typename Frame>
-class Aero : public ForcefullObject<Frame> {
+template <typename External>
+class Aero : public ForcefullObject<External>, public TorquedObject<External> {
+    using Internal = ISO8855;
+
+    Transform<Internal, External> toExternal;
+
+    Force<Internal> internalForce;
+    Torque<Internal> internalTorque;
+
     float cla;
-    
-    void downforce(VehicleState<Frame> state, float airDensity, Vec<Frame> wind);
+
+    void calculateInternal(float airDensity, float speedSq);
 
    public:
     Aero(const Config& config);
     Aero() = default;
-    void calculate(VehicleState<Frame> state, float airDensity, Vec<Frame> wind = {});
+    void calculate(VehicleState<External> state, float airDensity, Vec<External> wind = {});
 };
 
 #include "aero.inl"

--- a/src/vehicle/aero/aero.inl
+++ b/src/vehicle/aero/aero.inl
@@ -1,18 +1,20 @@
-#include "vehicle/aero/aero.h"
-
 #include "config/config.h"
-#include "vehicle/vehicleHelper.h"
+#include "coordTypes.h"
 #include "types.h"
+#include "vehicle/aero/aero.h"
+#include "vehicle/vehicleHelper.h"
 
-template <typename Frame>
-Aero<Frame>::Aero(const Config& config) : cla(config.get("Vehicle", "cla")) {}
+template <typename External>
+Aero<External>::Aero(const Config& config) : cla(config.get("Vehicle", "cla")) {}
 
-template <typename Frame>
-void Aero<Frame>::calculate(VehicleState<Frame> state, float airDensity, Vec<Frame> wind) {
-    downforce(state, airDensity, wind);
+template <typename External>
+void Aero<External>::calculateInternal(float airDensity, float speedSq) {
+    internalForce.value.z = Z<Internal>{-0.5f * cla * airDensity * speedSq};
 }
 
-template <typename Frame>
-void Aero<Frame>::downforce(VehicleState<Frame> state, float airDensity, Vec<Frame> wind) {
-    this->force.value.z = Z<Frame>{static_cast<float>(-0.5 * cla * airDensity * std::pow(state.velocity.getLength(), 2))};
+template <typename External>
+void Aero<External>::calculate(VehicleState<External> state, float airDensity, Vec<External>) {
+    calculateInternal(airDensity, std::pow(state.velocity.getLength(), 2));
+    this->force.value = toExternal(internalForce.value);
+    this->torque = Torque<External>(toExternal(internalTorque));
 }

--- a/src/vehicle/vehicle.inl
+++ b/src/vehicle/vehicle.inl
@@ -335,8 +335,9 @@ WheelData<float> Vehicle<Frame>::aeroLoad(const Config& config) {
     Vec<Frame> wind = config.getVec<Frame>("Environment", "wind");
 
     aero.value.calculate(state, airDensityVal, wind);
-    // TODO: cla sign bug — force.z > 0 = lift, negate to get downforce
-    return distributeForces(-aero.value.getForce().value.z.v, aero.position.x.v, aero.position.y.v);
+    Transform<Frame, ISO8855> toIso;
+    float downforce = -toIso(aero.value.getForce().value.z).v;
+    return distributeForces(downforce, aero.position.x.v, aero.position.y.v);
 }
 
 template <typename Frame>


### PR DESCRIPTION
aero used a single Frame template that conflated physics frame and vehicle frame. moved to internal/external pattern matching Tire: internal=ISO8855 (where downforce is computed), external=vehicle frame (where force is exposed). conversion via Transform at the public interface.

This brings aero in line with the established pattern. vehicle still implicitly assumes ISO8855 in places (wheel positions, distributeForces geometry, yaw rate sign) — full frame-invariance is a separate later refactor.

also inherits `TorquedObject<External>` as scaffold for aero moments (yaw/pitch/roll), which are currently TODO in vehicle.inl. no behavior change in this PR — internal torque init to zero.

ymd at default config is bit-identical to PR2 tip (pure refactor).